### PR TITLE
Add plugin flag to dev-vars

### DIFF
--- a/vars/dev-vars.yaml
+++ b/vars/dev-vars.yaml
@@ -4,3 +4,6 @@ namespace: aicoe-argocd-dev
 # from cmd line using bcrypt function (-B).
 admin_password: "$2y$10$sz90EbrYgrCQXwjbwTpKEeTbaXZb4spJ8J23hg58DEI5/CCWl7DN6"
 repo_server_image: quay.io/aicoe/argocd:v1.5.2-1
+argo_cm: |
+  data:
+    kustomize.buildOptions: "--enable_alpha_plugins"


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [X] No

## Description
This adds the "enable_alpha_plugins" flag to the dev-vars so ksops can run w/o issues by default. 