### PR TITLE
Add openshift authentication

### DIFF
--- a/objects/namespace-install.yaml
+++ b/objects/namespace-install.yaml
@@ -2060,7 +2060,6 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-cm
-{{ argo_cm | default('') }}
 
 ---
 apiVersion: v1

--- a/objects/patches/admin_creds_patch.yaml
+++ b/objects/patches/admin_creds_patch.yaml
@@ -4,8 +4,5 @@ stringData:
   admin.passwordMtime: {{ lookup('pipe','date +%FT%T%Z') }}
 kind: Secret
 metadata:
-  labels:
-    app.kubernetes.io/name: argocd-secret
-    app.kubernetes.io/part-of: argocd
   name: argocd-secret
 type: Opaque

--- a/objects/patches/argocd_cm_patch.yaml
+++ b/objects/patches/argocd_cm_patch.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+{{ argo_cm | default('') }}

--- a/objects/patches/argocd_dex_dc_patch.yaml
+++ b/objects/patches/argocd_dex_dc_patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - /shared/argocd-util
+        - rundex
+        image: quay.io/dexidp/dex:v2.22.0
+        imagePullPolicy: Always
+        name: dex
+        ports:
+        - containerPort: 5556
+        - containerPort: 5557
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files

--- a/objects/patches/argocd_dex_sa_patch.yaml
+++ b/objects/patches/argocd_dex_sa_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-dex-server
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirecturi.aicoe-argocd: >-
+      {{ redirectURI }}

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -55,14 +55,60 @@
         - objects/namespace-install.yaml
         - objects/argocd_server_route.yaml
 
-    - name: Patch ArgoCD admin psw
+    - name: Get OpenShift API server
+      shell: oc whoami --show-server
+      register: api_server
+
+    - name: Get Dex Service Account
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: ServiceAccount
+        name: argocd-dex-server
+        namespace: "{{ namespace }}"
+        verify_ssl: no
+      register: dex_sa
+
+    - name: Get Dex Service Account Secrets
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Secret
+        name: "{{ item.name }}"
+        namespace: "{{ namespace }}"
+        verify_ssl: no
+      register: dex_sa_secrets
+      when: "'token' in item.name"
+      with_items: "{{ dex_sa.resources[0].secrets }}"
+
+    - set_fact:
+        dex_sa_token: "{{ item.resources[0].data.token | b64decode }}"
+      when: "'resources' in item"
+      with_items: "{{ dex_sa_secrets.results }}"
+      no_log: True
+
+    - name: Get the ArgoCD Server Route
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Route
+        name: argocd-server
+        namespace: "{{ namespace }}"
+        verify_ssl: no
+      register: server_route
+
+    - name: Set Dex Connecter fields
+      set_fact:
+        argocd_url: "https://{{ server_route.resources[0].spec.host }}"
+        issuer: "{{ api_server.stdout }}"
+        clientID: "system:serviceaccount:{{ namespace }}:argocd-dex-server"
+        clientSecret: "{{ dex_sa_token }}"
+        redirectURI: "https://{{ server_route.resources[0].spec.host }}/api/dex/callback"
+
+    - name: Apply patches
       k8s:
         kubeconfig: "{{ kubeconfig }}"
         state: present
         namespace: "{{ namespace }}"
         verify_ssl: no
-        definition: "{{ lookup('template', item ) }}"
+        definition: "{{ lookup('template', 'objects/patches/'+item.path ) }}"
         merge_type:
-        - merge
-      with_items:
-        - objects/admin_creds_patch.yaml
+          - merge
+      with_filetree: objects/patches/

--- a/vars/prod-vars.yaml
+++ b/vars/prod-vars.yaml
@@ -6,6 +6,22 @@ admin_password: "$2y$10$18l2wN8YokC8rghRWbrhlu4kXCP7P9oJ7L45GHJ4RWsSR7zKXmnXy"
 repo_server_image: quay.io/aicoe/argocd:v1.5.2-1
 argo_cm: |
   data:
+    url: {{ argocd_url }}
+    dex.config: |
+      connectors:
+        # OpenShift
+        - type: openshift
+          id: openshift
+          name: OpenShift
+          config:
+            issuer: {{ issuer }}
+            clientID: {{ clientID }}
+            clientSecret: {{ clientSecret }}
+            redirectURI: {{ redirectURI }}
+            insecureCA: true
+            groups:
+              - data-hub-openshift-admins
+              - aicoe-thoth-devops
     kustomize.buildOptions: "--enable_alpha_plugins"
     repositories: |
       - type: git


### PR DESCRIPTION
## This introduces a breaking change

- [x] Yes
- [ ] No

## This Pull Request implements

Openshift Authentication via Oauth server

## Description

This PR will implement Openshift authentication via the Argocd Dex connector. 

Note that I include a patch that bumps the dex version to 2.22, this is because 2.21 does not have Openshift support (afaik this is slated to be shipped with the next release of ArgoCD). 

Also removed some redundant labels in the secrets patch (not needed). 