### PR TITLE
Add RBAC restrictions

### DIFF
--- a/objects/patches/argocd_rbac_cm_patch.yaml
+++ b/objects/patches/argocd_rbac_cm_patch.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+{{ argo_rbac_cm | default('') }}

--- a/objects/projects/projects.yaml
+++ b/objects/projects/projects.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: thoth
+  namespace: {{ namespace }}
+spec:
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: data-hub
+  namespace: {{ namespace }}
+spec:
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*'

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -55,6 +55,17 @@
         - objects/namespace-install.yaml
         - objects/argocd_server_route.yaml
 
+    - name: Deploy the ArgoCD projects
+      k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        namespace: "{{ namespace }}"
+        verify_ssl: no
+        definition: "{{ lookup('template', item) }}"
+      with_items:
+        - objects/projects/projects.yaml
+      when: target_env == 'prod'
+
     - name: Get OpenShift API server
       shell: oc whoami --show-server
       register: api_server

--- a/vars/prod-vars.yaml
+++ b/vars/prod-vars.yaml
@@ -40,3 +40,41 @@ argo_cm: |
         - "TaskRun"
         clusters:
         - "*"
+
+argo_rbac_cm: |
+  data:
+    policy.csv: |
+      p, role:argocd-admin, certificates, get, *, allow
+      p, role:argocd-admin, certificates, create, *, allow
+      p, role:argocd-admin, certificates, update, *, allow
+      p, role:argocd-admin, clusters, get, *, allow
+      p, role:argocd-admin, clusters, create, *, allow
+      p, role:argocd-admin, clusters, update, *, allow
+      p, role:argocd-admin, repositories, get, *, allow
+      p, role:argocd-admin, repositories, create, *, allow
+      p, role:argocd-admin, repositories, update, *, allow
+      p, role:argocd-admin, projects, get, *, allow
+      p, role:argocd-admin, projects, create, *, allow
+      p, role:argocd-admin, projects, update, *, allow
+      p, role:argocd-admin, accounts, get, *, allow
+      p, role:argocd-admin, accounts, update, *, allow
+
+      p, role:thoth-admin, applications, get, thoth/*, allow
+      p, role:thoth-admin, applications, create, thoth/*, allow
+      p, role:thoth-admin, applications, update, thoth/*, allow
+      p, role:thoth-admin, applications, delete, thoth/*, allow
+      p, role:thoth-admin, applications, sync, thoth/*, allow
+      p, role:thoth-admin, applications, override, thoth/*, allow
+      p, role:thoth-admin, applications, action/*, thoth/*, allow
+      g, aicoe-thoth-devops, role:argocd-admin
+      g, aicoe-thoth-devops, role:thoth-admin
+
+      p, role:data-hub-admin, applications, get, data-hub/*, allow
+      p, role:data-hub-admin, applications, create, data-hub/*, allow
+      p, role:data-hub-admin, applications, update, data-hub/*, allow
+      p, role:data-hub-admin, applications, delete, data-hub/*, allow
+      p, role:data-hub-admin, applications, sync, data-hub/*, allow
+      p, role:data-hub-admin, applications, override, data-hub/*, allow
+      p, role:data-hub-admin, applications, action/*, data-hub/*, allow
+      g, data-hub-openshift-admins, role:argocd-admin
+      g, data-hub-openshift-admins, role:data-hub-admin


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## Description

The PR adds two ArgoCD projects: `thoth` and `data-hub` and policies that create the `thoth-admin` and `data-hub-admin` ArgoCD roles (which will be assigned to Openshift groups)