### PR TITLE
Apply flag to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ ansible-playbook --ask-vault-pass playbook.yaml \
 
 ### Ignore cluster objects
 If you want to just update deployment/configs or other namespace scoped objects
-without requiring cluster-admin, just add the additional `deploy_cluster_objects=False` var: 
+without requiring cluster-admin, just add the additional `cluster_admin=False` var: 
 
 ```bash
 pipenv shell
 pipenv install
 ansible-playbook --ask-vault-pass playbook.yaml \
-  -e deploy_cluster_objects=False \
+  -e cluster_admin=False \
   -e kubeconfig=$HOME/.kube/config \
   -e target_env=prod
 ```

--- a/objects/namespace-install.yaml
+++ b/objects/namespace-install.yaml
@@ -1,4 +1,4 @@
-{% if deploy_cluster_objects | bool %}
+{% if cluster_admin | bool %}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -18,7 +18,7 @@
 
     - name: Verify cluster object deployment
       set_fact:
-        deploy_cluster_objects: "{{ deploy_cluster_objects | default(True) }}"
+        cluster_admin: "{{ cluster_admin | default(True) }}"
 
     - name: Load gpg key
       include_vars:
@@ -64,7 +64,7 @@
         definition: "{{ lookup('template', item) }}"
       with_items:
         - objects/projects/projects.yaml
-      when: target_env == 'prod'
+      when: (target_env == 'prod') and (cluster_admin | bool)
 
     - name: Get OpenShift API server
       shell: oc whoami --show-server


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## Description
Creating AppProjects currently requires cluster admin, so I added the flag so we can choose not to deploy this if when running playbook as non-cluster admin. (I also updated the var name, since AppProject isn't technically a cluster object). 